### PR TITLE
fix: added skip_serialization for JSON fields

### DIFF
--- a/json/jsonrpc/src/convention.rs
+++ b/json/jsonrpc/src/convention.rs
@@ -104,11 +104,13 @@ pub struct Response {
     /// This member is REQUIRED on success.
     /// This member MUST NOT exist if there was an error invoking the method.
     /// The value of this member is determined by the method invoked on the Server.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub result: Value,
 
     // This member is REQUIRED on error.
     // This member MUST NOT exist if there was no error triggered during invocation.
     // The value for this member MUST be an Object as defined in section 5.1.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub error: Option<ErrorData>,
 
     /// This member is REQUIRED.


### PR DESCRIPTION
added skip_serialization for JSON fields that should not be present if value is None